### PR TITLE
fix(nodejs): use hard-coded localhost

### DIFF
--- a/templates/nodejs/src/index.ts
+++ b/templates/nodejs/src/index.ts
@@ -11,5 +11,5 @@ serve({
   fetch: app.fetch,
   port: 3000
 }, (info) => {
-  console.log(`Server is running on http://${info.address}:${info.port}`)
+  console.log(`Server is running on http://localhost:${info.port}`)
 })


### PR DESCRIPTION
With `info.address`, it may output:
```
http://::1:3000
```

where the correct output should be
```
http://[::1]:3000
```

This can be fixed by instead using:
```ts
  (info) => {
    const host = info.family === 'IPv6' ? `[${info.address}]` : info.address;
    console.log(`Hono internal server: http://${host}:${info.port}`);
  },
```

However, to keep the starting template simple as [recommended](https://github.com/honojs/starter/pull/75#issuecomment-2670692743), localhost is preferred.